### PR TITLE
Revert "build(deps): bump gatsby-plugin-loadable-components-ssr from 3.2.0 to 4.1.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "gatsby-plugin-gatsby-cloud": "^3.2.0",
         "gatsby-plugin-google-fonts": "^1.0.1",
         "gatsby-plugin-image": "^1.11.0",
-        "gatsby-plugin-loadable-components-ssr": "^4.1.2",
+        "gatsby-plugin-loadable-components-ssr": "^3.2.0",
         "gatsby-plugin-react-helmet": "^4.14.0",
         "gatsby-source-filesystem": "^3.14.0",
         "gatsby-transformer-csv": "^3.14.0",
@@ -10611,12 +10611,13 @@
       }
     },
     "node_modules/gatsby-plugin-loadable-components-ssr": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-loadable-components-ssr/-/gatsby-plugin-loadable-components-ssr-4.1.2.tgz",
-      "integrity": "sha512-vJ4Hu5eek6s1oPwwo3yB8/8cfKsmGkBONTL2WUPXhjVt0n4wkC9F0DQ3psu8d9Fz/75oHAvKeLCyG4bTtPTCqg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-loadable-components-ssr/-/gatsby-plugin-loadable-components-ssr-3.2.0.tgz",
+      "integrity": "sha512-l24u8R9/JB+XnqMWijEgMG1jsDYZJQSvJsGWCqAlqe7T4MhxN95OGUsbLHwpASBnb/QPYS77WnMkxqpbpZT3hQ==",
       "dependencies": {
         "@babel/runtime": "^7.9.6",
         "@loadable/babel-plugin": "^5.13.2",
+        "@loadable/component": "^5.15.0",
         "@loadable/server": "^5.15.0",
         "@loadable/webpack-plugin": "^5.15.0"
       },
@@ -10624,8 +10625,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "@loadable/component": "^5.15.0",
-        "gatsby": "^2.12.1 || ^3.0.0 || ^4.0.0",
+        "gatsby": "^2.12.1 || ^3.0.0",
         "react-dom": "^16.12.0 || ^17.0.1"
       }
     },
@@ -31043,12 +31043,13 @@
       }
     },
     "gatsby-plugin-loadable-components-ssr": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-loadable-components-ssr/-/gatsby-plugin-loadable-components-ssr-4.1.2.tgz",
-      "integrity": "sha512-vJ4Hu5eek6s1oPwwo3yB8/8cfKsmGkBONTL2WUPXhjVt0n4wkC9F0DQ3psu8d9Fz/75oHAvKeLCyG4bTtPTCqg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-loadable-components-ssr/-/gatsby-plugin-loadable-components-ssr-3.2.0.tgz",
+      "integrity": "sha512-l24u8R9/JB+XnqMWijEgMG1jsDYZJQSvJsGWCqAlqe7T4MhxN95OGUsbLHwpASBnb/QPYS77WnMkxqpbpZT3hQ==",
       "requires": {
         "@babel/runtime": "^7.9.6",
         "@loadable/babel-plugin": "^5.13.2",
+        "@loadable/component": "^5.15.0",
         "@loadable/server": "^5.15.0",
         "@loadable/webpack-plugin": "^5.15.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gatsby-plugin-gatsby-cloud": "^3.2.0",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-image": "^1.11.0",
-    "gatsby-plugin-loadable-components-ssr": "^4.1.2",
+    "gatsby-plugin-loadable-components-ssr": "^3.2.0",
     "gatsby-plugin-react-helmet": "^4.14.0",
     "gatsby-source-filesystem": "^3.14.0",
     "gatsby-transformer-csv": "^3.14.0",

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -89,4 +89,5 @@ footer.footer {
   margin: 0;
 }
 .footer .footer__link-about {
+  white-space: nowrap;
 }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -25,7 +25,7 @@ const Layout = ({children, className = ''}) => {
           About
         </Link>
         <a href="https://lot.almost-dead.net" className="footer__logo-lot" title="JRAD Forum — The Lot">
-          <img src="https://i.imgur.com/Qi2NhJO.png" alt="The Lot — a forum for fans of Joe Russo's Almost Dead" />
+          The Lot (forum)
         </a>
       </footer>
 


### PR DESCRIPTION
Reverts alxndr/almost-dead-net#369